### PR TITLE
レターを送っている場合にエラーになる問題の解決

### DIFF
--- a/src/bin/colmsg/main.rs
+++ b/src/bin/colmsg/main.rs
@@ -60,6 +60,8 @@ fn run() -> Result<bool> {
         }
     }
 
+    if let Err(_e) = &result { return result; }
+
     result = run_hinatazaka(&app);
     loop {
         match &result {

--- a/src/http/timeline.rs
+++ b/src/http/timeline.rs
@@ -37,7 +37,7 @@ pub struct TimelineLetters {
     pub id: u32,
     pub is_favorite: bool,
     pub member_id: u32,
-    pub opened_at: String,
+    pub opened_at: Option<String>,
     pub text: String,
     pub thumbnail: String,
     pub thumbnail_height: u32,


### PR DESCRIPTION
refs: https://github.com/proshunsuke/colmsg/issues/41

timelineのAPIで返ってくるjsonの `letters` にはレターを送った内容が書かれており、そこに `opened_at` というキーも入ってくる想定でいた。しかし、おそらくこの値はメンバーがレターを開かないと入ってこないらしく、その場合はそもそも `opened_at` というキーは存在しないのでエラーになっていた
option型にすることで `opened_at` が無くてもエラーにならないようにした

また、櫻坂のメッセージを保存する場合にエラーになる場合はエラーメッセージを表示せずに死ぬようになっていたので、ちゃんとエラーメッセージが吐かれるように修正した
