### PR TITLE
日向坂のメッセージが保存出来ない問題の解決

### DIFF
--- a/src/bin/colmsg/app.rs
+++ b/src/bin/colmsg/app.rs
@@ -9,7 +9,6 @@ use colmsg::{
     dirs::PROJECT_DIRS,
     errors::*,
     Config,
-    Group,
     Kind,
     http::client::{SClient, SHClient, HClient}
 };
@@ -54,12 +53,6 @@ impl App {
     }
 
     fn config<S: AsRef<str>, C: SHClient>(&self, refresh_token_str: S, client: C) -> Result<Config<C>> {
-        let group = match self.matches.value_of("group") {
-            Some("sakurazaka") => Group::Sakurazaka,
-            Some("hinatazaka") => Group::Hinatazaka,
-            _ => Group::All
-        };
-
         let name = match self.matches.values_of("name") {
             Some(names) => {
                 names
@@ -109,6 +102,6 @@ impl App {
             .unwrap_or_else(|| String::from("invalid_refresh_token"));
 
         let access_token = get_access_token_from_file(&refresh_token, client.clone())?;
-        Ok(Config { group, name, from, kind, dir, client: client.clone(), access_token })
+        Ok(Config { name, from, kind, dir, client: client.clone(), access_token })
     }
 }

--- a/src/bin/colmsg/main.rs
+++ b/src/bin/colmsg/main.rs
@@ -12,7 +12,7 @@ use reqwest::StatusCode;
 use crate::{app::App, config::delete_access_token_file};
 
 use colmsg::dirs::PROJECT_DIRS;
-use colmsg::{errors::*, Config, Group};
+use colmsg::{errors::*, Config};
 use colmsg::errors::ErrorKind::ReqwestError;
 use colmsg::controller::Controller;
 use colmsg::http::client::{SClient, SHClient, HClient};
@@ -23,18 +23,22 @@ fn run_controller<C: SHClient>(config: &Config<C>) -> Result<bool> {
 }
 
 fn run_sakurazaka(app: &App) -> Result<bool> {
-    let config: Config<SClient> = app.sakurazaka_config()?;
-    match &config.group {
-        Group::Sakurazaka | Group::All => run_controller(&config),
-        _ => Ok(true)
+    match app.matches.value_of("group") {
+        Some("hinatazaka") => Ok(true),
+        _ => {
+            let config: Config<SClient> = app.sakurazaka_config()?;
+            run_controller(&config)
+        }
     }
 }
 
 fn run_hinatazaka(app: &App) -> Result<bool> {
-    let config: Config<HClient> = app.hinatazaka_config()?;
-    match &config.group {
-        Group::Hinatazaka | Group::All => run_controller(&config),
-        _ => Ok(true)
+    match app.matches.value_of("group") {
+        Some("sakurazaka") => Ok(true),
+        _ => {
+            let config: Config<HClient> = app.hinatazaka_config()?;
+            run_controller(&config)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,13 +49,6 @@ use chrono::{NaiveDateTime};
 use crate::http::client::SHClient;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Group {
-    Sakurazaka,
-    Hinatazaka,
-    All,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Kind {
     Text,
     Picture,
@@ -64,7 +57,6 @@ pub enum Kind {
 }
 
 pub struct Config<'a, C: SHClient> {
-    pub group: Group,
     pub name: Vec<&'a str>,
     pub from: Option<NaiveDateTime>,
     pub kind: Vec<Kind>,


### PR DESCRIPTION
refs: https://github.com/proshunsuke/colmsg/issues/46

* 必ず櫻坂のaccess_tokenを取得するようになっていた
  * その後に日向坂のメッセージ保存処理を開始するようになっていた
* 今まではエラーを握りつぶしていたのでたとえ櫻坂のaccess_tokenの取得に失敗したとしてもそのまま日向坂のメッセージの取得処理を開始していたが、エラーをちゃんと表示するようにしたので日向坂のメッセージだけを取得したい場合に今度は日向坂のメッセージの保存処理まで進まなくなった
* 今まではconfigのGroupの値を見ていたがそれを廃止して、初っ端からユーザーの入力値のgroupをチェックして櫻坂・日向坂の処理を行うかどうかを決定するようにした