### PR TITLE
Ignore the filenames that are not in correct format

### DIFF
--- a/src/message/saver.rs
+++ b/src/message/saver.rs
@@ -216,17 +216,9 @@ struct IdDate {
 
 fn dir_entry_to_id_date(filename: &DirEntry) -> Option<IdDate> {
     let re = Regex::new(r"(?x)(?P<id>\d+)_\d_(?P<date>\d+)").unwrap();
-    let caps = &re.captures(filename.file_name().to_str().unwrap());
-
-    match caps {
-        None => {
-            None
-        }
-        Some(cap) => {
-            Some(IdDate {
-                id: cap["id"].parse::<u32>().unwrap(),
-                date: cap["date"].to_string()
-            })
-        }
-    }
+    re.captures(filename.file_name().to_str().unwrap())
+        .and_then(|cap|Some(IdDate {
+            id: cap["id"].parse::<u32>().unwrap(),
+            date: cap["date"].to_string()
+        }))
 }

--- a/src/message/saver.rs
+++ b/src/message/saver.rs
@@ -173,17 +173,17 @@ impl<'b, C: SHNClient> Saver<'b, C> {
     }
 
     fn id_dates(&self, dir_buf: &PathBuf) -> Vec<IdDate> {
-        WalkDir::new(dir_buf)
-            .sort_by(move |a, b| {
-                id_by_filename_format(&a).cmp(&id_by_filename_format(&b))
-            })
+        let mut result = WalkDir::new(dir_buf)
             .into_iter()
             .filter(|r| !r.as_ref().unwrap().path().is_dir())
             .map(|r| {
                 let dir_entry = r.unwrap();
-                IdDate { id: id_by_filename_format(&dir_entry), date: date_by_filename_format(&dir_entry) }
+                dir_entry_to_id_date(&dir_entry)
             })
-            .collect::<Vec<_>>()
+            .flatten()
+            .collect::<Vec<_>>();
+        result.sort_by(|a, b| a.id.cmp(&b.id));
+        result
     }
 
     fn latest_date(&self, id_dates: &Vec<IdDate>) -> Result<String> {
@@ -214,14 +214,19 @@ struct IdDate {
     date: String,
 }
 
-fn id_by_filename_format(filename: &DirEntry) -> u32 {
-    let re = Regex::new(r"(?x)(?P<id>\d+)_*").unwrap();
-    let caps = &re.captures(filename.file_name().to_str().unwrap()).unwrap();
-    caps["id"].parse::<u32>().unwrap()
-}
+fn dir_entry_to_id_date(filename: &DirEntry) -> Option<IdDate> {
+    let re = Regex::new(r"(?x)(?P<id>\d+)_\d_(?P<date>\d+)").unwrap();
+    let caps = &re.captures(filename.file_name().to_str().unwrap());
 
-fn date_by_filename_format(filename: &DirEntry) -> String {
-    let re = Regex::new(r"(?x)\d+_\d_(?P<date>\d+)").unwrap();
-    let caps = &re.captures(filename.file_name().to_str().unwrap()).unwrap();
-    caps["date"].to_string()
+    match caps {
+        None => {
+            None
+        }
+        Some(cap) => {
+            Some(IdDate {
+                id: cap["id"].parse::<u32>().unwrap(),
+                date: cap["date"].to_string()
+            })
+        }
+    }
 }


### PR DESCRIPTION
The original logic for creating the vector of IdDate will try to capture the ID and date from filename.
But OS such as macOS will generate resource file `.DS_Store` in folders and the process will be paniked.


Replace `id_by_filename_format` and `date_by_filename_format` with `dir_entry_to_id_date`

Ref: #84