### PR TITLE
Fix default Download folder cause panic on Linux

### DIFF
--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,18 +1,18 @@
-use std::path::{Path, PathBuf};
 use crate::dirs_rs;
+use std::path::{Path, PathBuf};
 
 #[cfg(target_os = "macos")]
 use std::env;
 
 pub struct ColmsgProjectDirs {
     config_dir: PathBuf,
-    download_dir: PathBuf
+    download_dir: PathBuf,
 }
 
 impl ColmsgProjectDirs {
     fn new() -> Option<ColmsgProjectDirs> {
         #[cfg(target_os = "macos")]
-            let config_dir_op = env::var_os("XDG_CONFIG_HOME")
+        let config_dir_op = env::var_os("XDG_CONFIG_HOME")
             .map(PathBuf::from)
             .filter(|p| p.is_absolute())
             .or_else(|| dirs_rs::home_dir().map(|d| d.join(".config")));
@@ -21,16 +21,25 @@ impl ColmsgProjectDirs {
         let config_dir_op = dirs_rs::config_dir();
         let config_dir = config_dir_op.map(|d| d.join("colmsg"))?;
 
+        #[cfg(not(target_os = "linux"))]
         let download_dir_op = dirs_rs::download_dir();
+
+        #[cfg(target_os = "linux")]
+        let download_dir_op =
+            dirs_rs::download_dir().or_else(|| dirs_rs::home_dir().map(|d| d.join("Downloads")));
         let download_dir = download_dir_op.map(|d| d.join("colmsg"))?;
 
         Some(ColmsgProjectDirs {
             config_dir,
-            download_dir
+            download_dir,
         })
     }
-    pub fn config_dir(&self) -> &Path { &self.config_dir }
-    pub fn download_dir(&self) -> &Path { &self.download_dir }
+    pub fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+    pub fn download_dir(&self) -> &Path {
+        &self.download_dir
+    }
 }
 
 lazy_static! {


### PR DESCRIPTION
The `dirs` crate uses environment variable `XDG_DOWNLOAD_DIR` as the [download_dir](https://docs.rs/dirs/2.0.2/dirs/fn.download_dir.html) on Linux.
Some distro isn't configure [XDG user directory](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) by default and cause panic.

This commit updated to use `$HOME/Downloads` as the fallback directory if `XDG_DOWNLOAD_DIR` is not set.

