### PR TITLE
add: build apple silicon statement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ release/x86_64-win:
 	cross build --release --target x86_64-pc-windows-gnu
 	@cd target/x86_64-pc-windows-gnu/release/ && zip colmsg-v${VERSION}-x86_64-pc-windows-gnu.zip colmsg.exe
 
+release/aarch64-darwin:
+	cargo build --release --target aarch64-apple-darwin
+	tar -C target/aarch64-apple-darwin/release -czvf target/aarch64-apple-darwin/release/colmsg-v${VERSION}-aarch64-apple-darwin.tar.gz colmsg
+
 server/kh:
 	docker-compose up swagger-api-kh
 


### PR DESCRIPTION
Purpose: Create a build statement for Apple Silicon(M1/M2)

I added a simple build command to build the `colmsg` for Apple Silicon use since my laptop is M2 Macbook Air.
What if you do not have Apple Silicon but Intel Mac, the environment should be add the build target with `rustup target add aarch64-apple-darwin`

---

To be verified:
The $Version could be process under `cargo 1.74.0` to build the binary. The `$VERSION` could be no file been found. 
However, the outcome `$(shell pwd)/target/aarch64-apple-darwin/release/colmsg`. This could be discuss how to get the right outcome binary. 

