### PR TITLE
Add automated release workflows for GitHub Actions

### DIFF
--- a/.github/workflows/aur-update.yml
+++ b/.github/workflows/aur-update.yml
@@ -1,0 +1,169 @@
+name: Update AUR
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'ドライラン実行（AURを更新せず確認のみ）'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  update-aur:
+    runs-on: ubuntu-latest
+    container: archlinux/archlinux:base-devel
+    steps:
+      - name: Install required packages
+        run: |
+          pacman -Syu --noconfirm
+          pacman -S --noconfirm git namcap
+      
+      - name: Set version
+        id: version
+        run: |
+          # タグからバージョンを取得
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ -z "$VERSION" || "$VERSION" == "$GITHUB_REF" ]]; then
+            echo "❌ エラー: バージョンタグが見つかりません"
+            echo "このワークフローはタグ付きで実行する必要があります"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+      
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.AUR_SSH_PRIVATE_KEY }}" > ~/.ssh/aur
+          chmod 600 ~/.ssh/aur
+          echo "Host aur.archlinux.org
+            User aur
+            IdentityFile ~/.ssh/aur
+            StrictHostKeyChecking no" > ~/.ssh/config
+      
+      - name: Clone AUR package
+        run: |
+          git clone ssh://aur@aur.archlinux.org/colmsg.git aur-colmsg
+      
+      - name: Update PKGBUILD
+        run: |
+          cd aur-colmsg
+          VERSION=${{ steps.version.outputs.version }}
+          VERSION=${VERSION#v}  # v prefix を削除
+          
+          echo "=== Current PKGBUILD ==="
+          cat PKGBUILD
+          echo "======================="
+          
+          # PKGBUILDのバージョンを更新
+          sed -i "s/pkgver=.*/pkgver=$VERSION/" PKGBUILD
+          
+          # ソースのコミットハッシュを更新
+          COMMIT_HASH=$(git ls-remote https://github.com/${{ github.repository }}.git refs/tags/v$VERSION | cut -f1)
+          if [[ -z "$COMMIT_HASH" ]]; then
+            echo "❌ エラー: タグ v$VERSION が見つかりません"
+            exit 1
+          fi
+          echo "✅ コミットハッシュ: $COMMIT_HASH"
+          sed -i "s/source=.*/source=(\"git+https:\/\/github.com\/${{ github.repository }}.git#commit=$COMMIT_HASH\")/" PKGBUILD
+          
+          echo -e "\n=== Updated PKGBUILD ==="
+          cat PKGBUILD
+          echo "======================="
+      
+      - name: Validate PKGBUILD syntax
+        run: |
+          cd aur-colmsg
+          echo "📋 PKGBUILDの構文チェック"
+          bash -n PKGBUILD && echo "✅ PKGBUILDの構文は正常です" || {
+            echo "❌ PKGBUILDに構文エラーがあります"
+            exit 1
+          }
+      
+      - name: Generate .SRCINFO
+        run: |
+          cd aur-colmsg
+          echo "📋 .SRCINFOの生成"
+          makepkg --printsrcinfo > .SRCINFO
+          echo "=== Generated .SRCINFO ==="
+          cat .SRCINFO
+          echo "========================="
+      
+      - name: Run namcap checks
+        run: |
+          cd aur-colmsg
+          echo "🔍 namcapによるPKGBUILDの検証"
+          namcap PKGBUILD || true
+          echo ""
+      
+      - name: Build package verification
+        run: |
+          cd aur-colmsg
+          echo "🏗️  パッケージのビルドテスト"
+          
+          # 非rootユーザーでビルド
+          useradd -m builder
+          chown -R builder:builder .
+          
+          # ビルドの実行
+          su builder -c "makepkg -sf --noconfirm" || {
+            echo "❌ ビルドに失敗しました"
+            exit 1
+          }
+          
+          echo "✅ ビルドが成功しました"
+          
+          # ビルドされたパッケージの情報表示
+          echo -e "\n=== ビルドされたパッケージ ==="
+          ls -la *.pkg.tar.*
+          
+          # パッケージの内容確認
+          echo -e "\n=== パッケージの内容 ==="
+          tar -tvf *.pkg.tar.* | head -20
+          
+          # namcapでパッケージをチェック
+          echo -e "\n🔍 namcapによるパッケージの検証"
+          namcap *.pkg.tar.* || true
+      
+      - name: Show git diff
+        run: |
+          cd aur-colmsg
+          echo "📝 Git差分"
+          git diff --color=always || echo "（新規ファイルの場合は差分なし）"
+          
+          # 新規ファイルの場合
+          git add -N PKGBUILD .SRCINFO 2>/dev/null || true
+          git diff --cached --color=always
+      
+      - name: Show final summary
+        run: |
+          cd aur-colmsg
+          echo "========================================="
+          echo "📊 最終確認サマリー"
+          echo "========================================="
+          echo "バージョン: ${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION#v}"  # v prefix を削除
+          echo "コミットメッセージ: colmsg version${VERSION}"
+          echo ""
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "🔍 ドライラン: 以下の操作はスキップされました"
+            echo "  - Gitへのコミット"
+            echo "  - AURへのプッシュ"
+          else
+            echo "✅ 実際のAUR更新を実行します"
+          fi
+          echo "========================================="
+      
+      - name: Commit and push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          cd aur-colmsg
+          git config user.name "${{ secrets.AUR_USERNAME }}"
+          git config user.email "${{ secrets.AUR_EMAIL }}"
+          git add PKGBUILD .SRCINFO
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION#v}"  # v prefix を削除
+          git commit -m "colmsg version${VERSION}"
+          git push

--- a/.github/workflows/homebrew-update.yml
+++ b/.github/workflows/homebrew-update.yml
@@ -1,0 +1,123 @@
+name: Update Homebrew
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'ドライラン実行（Homebrewを更新せず確認のみ）'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  update-homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: proshunsuke/homebrew-colmsg
+          token: ${{ secrets.HOMEBREW_TOKEN }}
+      
+      - name: Set version
+        id: version
+        run: |
+          # タグからバージョンを取得
+          VERSION=${GITHUB_REF#refs/tags/}
+          if [[ -z "$VERSION" || "$VERSION" == "$GITHUB_REF" ]]; then
+            echo "❌ エラー: バージョンタグが見つかりません"
+            echo "このワークフローはタグ付きで実行する必要があります"
+            exit 1
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+      
+      - name: Update formula
+        run: |
+          cd Formula
+          VERSION=${{ steps.version.outputs.version }}
+          
+          echo "=== Current Formula ==="
+          cat colmsg.rb
+          echo "======================"
+          
+          # x86_64とaarch64のSHA256を計算
+          X86_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION/colmsg-$VERSION-x86_64-apple-darwin.tar.gz"
+          ARM_URL="https://github.com/${{ github.repository }}/releases/download/$VERSION/colmsg-$VERSION-aarch64-apple-darwin.tar.gz"
+          
+          # SHA256の計算
+          echo "📋 SHA256の計算"
+          X86_SHA=$(curl -sL "$X86_URL" | shasum -a 256 | awk '{print $1}')
+          ARM_SHA=$(curl -sL "$ARM_URL" | shasum -a 256 | awk '{print $1}')
+          
+          echo "✅ Intel版のSHA256: $X86_SHA"
+          echo "✅ ARM版のSHA256: $ARM_SHA"
+          
+          echo ""
+          echo "VERSION: $VERSION"
+          echo "X86_URL: $X86_URL"
+          echo "X86_SHA: $X86_SHA"
+          echo "ARM_URL: $ARM_URL"
+          echo "ARM_SHA: $ARM_SHA"
+          
+          # Formulaファイルを更新
+          # URLとバージョンの更新（v3.2.0/colmsg-v3.2.0 → v3.2.1/colmsg-v3.2.1）
+          sed -i "s|/v[0-9.]\+/colmsg-v[0-9.]\+|/${VERSION}/colmsg-${VERSION}|g" colmsg.rb
+          
+          # Intel用SHA256の更新
+          sed -i "/Hardware::CPU.intel?/,/sha256/ s/sha256 \".*\"/sha256 \"$X86_SHA\"/" colmsg.rb
+          
+          # ARM用SHA256の更新
+          sed -i "/Hardware::CPU.arm?/,/sha256/ s/sha256 \".*\"/sha256 \"$ARM_SHA\"/" colmsg.rb
+          
+          echo -e "\n=== Updated Formula ==="
+          cat colmsg.rb
+          echo "======================"
+      
+      - name: Validate Ruby syntax
+        run: |
+          cd Formula
+          echo "📋 Rubyファイルの構文チェック"
+          ruby -c colmsg.rb && echo "✅ Formulaの構文は正常です" || {
+            echo "❌ Formulaに構文エラーがあります"
+            exit 1
+          }
+      
+      - name: Show git diff
+        run: |
+          echo "📝 Git差分"
+          git diff --color=always
+          
+          # 差分がない場合の警告
+          if [[ -z "$(git diff)" ]]; then
+            echo "⚠️  警告: 変更がありません。バージョンが既に更新済みの可能性があります。"
+          fi
+      
+      - name: Show final summary
+        run: |
+          echo "========================================="
+          echo "📊 最終確認サマリー"
+          echo "========================================="
+          echo "バージョン: ${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION#v}"  # v prefix を削除
+          echo "コミットメッセージ: colmsg version${VERSION}"
+          echo ""
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "🔍 ドライラン: 以下の操作はスキップされました"
+            echo "  - Gitへのコミット"
+            echo "  - GitHubへのプッシュ"
+          else
+            echo "✅ 実際のHomebrew更新を実行します"
+          fi
+          echo "========================================="
+      
+      - name: Commit and push
+        if: ${{ !inputs.dry_run }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .
+          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${VERSION#v}"  # v prefix を削除
+          git commit -m "colmsg version${VERSION}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,160 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'ドライラン実行（リリースを作成せず確認のみ）'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Get version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=v$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Check if tag already exists
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.version.outputs.version }}"; then
+            echo "::warning::Tag ${{ steps.version.outputs.version }} already exists"
+            if [[ "${{ inputs.dry_run }}" != "true" ]]; then
+              echo "::error::Cannot create release - tag already exists"
+              exit 1
+            fi
+          fi
+      
+      - name: Show release info
+        run: |
+          echo "📋 リリース情報"
+          echo "バージョン: ${{ steps.version.outputs.version }}"
+          echo "タグ: refs/tags/${{ steps.version.outputs.version }}"
+          echo "CHANGELOG.md の存在: $(test -f CHANGELOG.md && echo '✅' || echo '❌')"
+          if [[ "${{ inputs.dry_run }}" == "true" ]]; then
+            echo "🔍 ドライランモードで実行中"
+          fi
+
+  build-binaries:
+    needs: get-version
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-13
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-14
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            archive: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      
+      - name: Setup Cross for Linux ARM
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross
+      
+      - name: Build binary
+        run: |
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+        shell: bash
+      
+      - name: Create archive
+        run: |
+          VERSION=${{ needs.get-version.outputs.version }}
+          ARCHIVE_NAME="colmsg-${VERSION}-${{ matrix.target }}"
+          
+          cd target/${{ matrix.target }}/release
+          
+          if [[ "${{ matrix.archive }}" == "zip" ]]; then
+            # Windows
+            7z a "../../../${ARCHIVE_NAME}.zip" colmsg.exe
+            echo "ARCHIVE_PATH=${ARCHIVE_NAME}.zip" >> $GITHUB_ENV
+          else
+            # Unix
+            tar -czf "../../../${ARCHIVE_NAME}.tar.gz" colmsg
+            echo "ARCHIVE_PATH=${ARCHIVE_NAME}.tar.gz" >> $GITHUB_ENV
+          fi
+        shell: bash
+      
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: colmsg-${{ matrix.target }}
+          path: ${{ env.ARCHIVE_PATH }}
+          retention-days: 7
+      
+      - name: Show build info
+        run: |
+          echo "✅ ビルド完了"
+          echo "ターゲット: ${{ matrix.target }}"
+          echo "アーカイブ: ${{ env.ARCHIVE_PATH }}"
+
+  create-release:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      
+      - name: List artifacts
+        run: |
+          echo "📦 ビルドされたアーティファクト:"
+          ls -la artifacts/*
+      
+      - name: Create Release
+        if: ${{ !inputs.dry_run }}
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/*/*.tar.gz,artifacts/*/*.zip"
+          tag: ${{ needs.get-version.outputs.version }}
+          name: ${{ needs.get-version.outputs.version }}
+          bodyFile: CHANGELOG.md
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Dry run - Show what would be released
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "🔍 ドライラン: 以下の内容でリリースが作成されます"
+          echo "タグ: ${{ needs.get-version.outputs.version }}"
+          echo "リリース名: ${{ needs.get-version.outputs.version }}"
+          echo "アーティファクト:"
+          find artifacts -name "*.tar.gz" -o -name "*.zip" | while read f; do
+            echo "  - $(basename $f)"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+このファイルは、このリポジトリでコードを扱う際のClaude Code (claude.ai/code) への指針を提供します。
+
+## プロジェクト概要
+
+colmsgは日本のアイドルグループのメッセージアプリ（櫻坂46、日向坂46、乃木坂46、齋藤飛鳥）からメッセージをダウンロードするRust製CLIアプリケーションです。メッセージとメディアファイルを適切に整理してローカルに保存します。
+
+## よく使う開発コマンド
+
+### ビルド
+```bash
+# 標準的なRustビルド
+cargo build
+cargo build --release
+
+# クロスプラットフォームリリースビルド
+make release/x86_64-linux    # Linux x86_64
+make release/x86_64-darwin   # macOS x86_64
+make release/aarch64-darwin  # macOS ARM64
+make release/x86_64-win      # Windows x86_64
+```
+
+### テスト
+```bash
+# テストの実行
+cargo test
+
+# モックサーバーでの実行（先にモックサーバーを起動）
+S_BASE_URL=http://localhost:8003 H_BASE_URL=http://localhost:8003 N_BASE_URL=http://localhost:8006 cargo run -- -d ~/Downloads/temp/
+```
+
+### 開発環境
+```bash
+# モックAPIサーバーの起動
+make server/kh     # 櫻坂/日向坂 API (ポート 8003)
+make server/n46    # 乃木坂 API (ポート 8006)
+
+# Swagger UIへのアクセス
+make open/ui/kh    # http://localhost:8002 を開く
+make open/ui/n46   # http://localhost:8005 を開く
+
+# サーバーの停止
+make stop/server/kh
+make stop/server/n46
+make down          # 全コンテナを停止
+```
+
+## アーキテクチャ
+
+### 主要モジュール
+- `src/bin/colmsg/`: CLIエントリーポイントとclapを使った引数解析
+- `src/controller.rs`: メッセージダウンロードを統括するメインアプリケーションコントローラー
+- `src/http/`: 各メッセージアプリAPI用のHTTPクライアント
+  - `sakurazaka.rs`, `hinatazaka.rs`, `nogizaka.rs`, `asuka_saito.rs`
+- `src/message/`: メッセージ処理と保存ロジック
+  - 異なるメッセージタイプ（テキスト、画像、動画、音声）を処理
+  - タイムスタンプベースのファイル名で保存
+
+### API統合
+- `/api/`内のOpenAPI仕様がメッセージアプリAPIを定義
+- 認証ヘッダー付きのHTTPリクエストにreqwestを使用
+- 環境変数経由で本番とモックAPIエンドポイントの両方をサポート
+
+### 設定
+- 設定ファイルにリフレッシュトークンとデフォルトオプションを保存
+- 場所: `~/.config/colmsg/` (または`COLMSG_CONFIG_PATH`経由)
+- メンバー/グループのフィルタリングとカスタム保存ディレクトリをサポート


### PR DESCRIPTION
## 関連URL

- N/A (No related issue)

## 概要

- Add comprehensive GitHub Actions workflows for automated release management
- Implement release.yml workflow for multi-platform binary builds and GitHub release creation
- Add aur-update.yml workflow for automated AUR (Arch User Repository) package updates
- Add homebrew-update.yml workflow for automated Homebrew formula updates

## Details

### release.yml
- Supports building binaries for multiple platforms:
  - Linux (x86_64, aarch64)
  - macOS (x86_64, aarch64)
  - Windows (x86_64)
- Features dry-run mode for testing without creating actual releases
- Automated version extraction from Cargo.toml
- Validates against duplicate tags before proceeding
- Creates GitHub releases with built artifacts and CHANGELOG.md content

### aur-update.yml
- Automates AUR package updates when new releases are tagged
- Runs in Arch Linux container for accurate environment
- Updates PKGBUILD with new version and commit hash
- Performs comprehensive validation:
  - PKGBUILD syntax checking
  - Package build testing
  - namcap validation for both PKGBUILD and built package
- Supports dry-run mode for testing changes

### homebrew-update.yml
- Automates Homebrew formula updates in the homebrew-colmsg repository
- Calculates SHA256 checksums for Intel and ARM macOS builds
- Updates formula file with new URLs and checksums
- Validates Ruby syntax before committing
- Supports dry-run mode for preview

## チェック項目

- [x] Revert可能
