### PR TITLE
Bump version to 3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Packaging
 
+# v3.2.2
+
+### Changes
+
+- Add automated release workflows for GitHub Actions
+- Add automated AUR package update workflow
+- Add automated Homebrew formula update workflow
+
 # v3.2.1
 
 ### Fix

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "colmsg"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
  "ansi_colours",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colmsg"
-version = "3.2.1"
+version = "3.2.2"
 authors = ["proshunsuke <shunsuke0901@gmail.com>"]
 categories = ["command-line-utilities"]
 description="Save the messages of '櫻坂46メッセージ', '日向坂46メッセージ' and '乃木坂46メッセージ' apps to the local."


### PR DESCRIPTION
## 関連URL

- 該当なし

## 概要

- バージョンを3.2.1から3.2.2に更新
- CHANGELOG.mdにv3.2.2のエントリーを追加
- GitHub Actionsで以下の自動化ワークフローを追加:
  - 自動リリースワークフロー
  - AURパッケージの自動更新ワークフロー
  - Homebrew formulaの自動更新ワークフロー

## チェック項目

- [x]  Revert可能