### PR TITLE
Release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Packaging
 
+# v3.3.0
+
+## Changes
+
+- Add basic support for Mai Shiraishi Message app (#118)
+  - New command-line option: `--m_refresh_token` for Mai Shiraishi messages
+  - Support for downloading messages and media from the Mai Shiraishi Message app
+
 # v3.2.2
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "colmsg"
-version = "3.2.2"
+version = "3.3.0"
 dependencies = [
  "ansi_colours",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "colmsg"
-version = "3.2.2"
+version = "3.3.0"
 authors = ["proshunsuke <shunsuke0901@gmail.com>"]
 categories = ["command-line-utilities"]
-description="Save the messages of '櫻坂46メッセージ', '日向坂46メッセージ' and '乃木坂46メッセージ' apps to the local."
+description="A CLI tool for '櫻坂46メッセージ', '日向坂46メッセージ', '乃木坂46メッセージ', '齋藤飛鳥メッセージ' and '白石麻衣メッセージ' app."
 homepage = "https://github.com/proshunsuke/colmsg"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## 関連URL

- https://github.com/proshunsuke/colmsg/pull/118

## 概要

- v3.3.0としてリリースするための変更
- 白石麻衣メッセージアプリのサポートを追加
- CHANGELOGを更新

## チェック項目

- [x]  Revert可能