### PR TITLE
link 種別の追加（種類番号4）

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ colmsg --help
     * 1: 画像
     * 2: 動画
     * 3: ボイス
+    * 4: リンク
 * 各環境毎のデフォルトの保存先は以下を実行することで確認することが出来ます
   * ```shell script
     colmsg --download-dir

--- a/src/bin/colmsg/app.rs
+++ b/src/bin/colmsg/app.rs
@@ -98,11 +98,13 @@ impl App {
                         "text" => Kind::Text,
                         "picture" => Kind::Picture,
                         "video" => Kind::Video,
-                        "voice" | _ => Kind::Voice, // _ はあり得ないはずだが怒られるのでとりあえずVoiceにする
+                        "voice" => Kind::Voice,
+                        "link" => Kind::Link,
+                        _ => Kind::Link, // _ はあり得ないはずだが怒られるのでとりあえずLinkにする
                     }
                 }).collect::<Vec<_>>()
             }
-            None => vec![Kind::Text, Kind::Picture, Kind::Video, Kind::Voice]
+            None => vec![Kind::Text, Kind::Picture, Kind::Video, Kind::Voice, Kind::Link]
         };
 
         let dir = self.matches

--- a/src/bin/colmsg/clap_app.rs
+++ b/src/bin/colmsg/clap_app.rs
@@ -48,7 +48,7 @@ e.g. -F '2020/01/01 00:00:00'")
                 .long("kind")
                 .short("k")
                 .multiple(true)
-                .possible_values(&["text", "picture", "video", "voice"])
+                .possible_values(&["text", "picture", "video", "voice", "link"])
                 .help("Save specific kind of messages.")
                 .long_help("Save specific kind of messages.
 If not specified, save all kinds of messages.

--- a/src/http/timeline.rs
+++ b/src/http/timeline.rs
@@ -16,16 +16,29 @@ pub struct TimelineMessages {
     pub is_favorite: bool,
     pub is_silent: bool,
     pub member_id: Option<u32>,
+    pub publish_type: Option<String>,
     pub published_at: String,
     pub state: String,
     pub text: Option<String>,
     #[serde(rename = "type")]
     pub messages_type: String,
+    // link 型でのみ出現する追加パラメータ
+    pub link_params: Option<LinkParams>,
     pub updated_at: String,
     pub file: Option<String>,
     pub thumbnail: Option<String>,
     pub thumbnail_height: Option<u32>,
     pub thumbnail_width: Option<u32>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LinkParams {
+    pub url: String,
+    pub method: String,
+    #[serde(rename = "sendid")]
+    pub send_id: Option<u32>,
+    // 仕様が不定のため汎用型で受ける
+    pub parameters: Vec<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@ pub enum Kind {
     Picture,
     Video,
     Voice,
+    Link,
 }
 
 pub struct Config<'a, C: SHNClient> {

--- a/src/message/saver.rs
+++ b/src/message/saver.rs
@@ -185,6 +185,16 @@ impl<'b, C: SHNClient> Saver<'b, C> {
                 );
                 message_file_voice.save()?
             }
+            "link" => {
+                // リンク型はテキストファイルとして保存するが、種別は Link として扱う
+                if !self.config.kind.contains(&Kind::Link) { return Ok(()); }
+                let message_file_text = Text::new(
+                    member_dir_buf,
+                    message::file::file_name(&message.id, &4, &message.updated_at)?,
+                    &message.text,
+                );
+                message_file_text.save()?
+            }
             _ => {
                 let err = format!("unknown type: {}", message.messages_type.as_str());
                 return Err(err.into());


### PR DESCRIPTION
- 種別に link を追加（種類番号 4、保存は .txt）
- CLI (--kind) と README を更新
- TimelineMessages に publish_type/link_params を追加

Related: https://github.com/proshunsuke/colmsg/issues/124