### PR TITLE
release/v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Packaging
 
+# v3.5.0
+
+## Changes
+
+- Add link kind (type number 4)
+
 # v3.4.0
 
 ## Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "colmsg"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "ansi_colours",
  "ansi_term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colmsg"
-version = "3.4.0"
+version = "3.5.0"
 authors = ["proshunsuke <shunsuke0901@gmail.com>"]
 categories = ["command-line-utilities"]
 description="A CLI tool for '櫻坂46メッセージ', '日向坂46メッセージ', '乃木坂46メッセージ', '齋藤飛鳥メッセージ', '白石麻衣メッセージ', and 'yodel' app."


### PR DESCRIPTION
Release v3.5.0

変更点
- link 種別を追加（種類番号 4）
- 保存処理: type=link を .txt として保存
- CLI: --kind に link を追加、未指定時のデフォルトに含める
- API 型: TimelineMessages に publish_type / link_params を追加
- README: 種類番号に 4: リンク を追記

関連
- 元PR: #125
- Issue: #124
- 参考: #123